### PR TITLE
enable metadata generation for Azure Functions deployment

### DIFF
--- a/Kebabify.Api/Kebabify.Api.csproj
+++ b/Kebabify.Api/Kebabify.Api.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <FunctionsEnableMetadataGeneration>true</FunctionsEnableMetadataGeneration>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The .azurefunctions directory is required for ZIP Deploy but was not being generated. Adding FunctionsEnableMetadataGeneration property fixes the InvalidPackageContentException during deployment.